### PR TITLE
Fix build error in Gradle Nightly Check

### DIFF
--- a/.github/actions/updateGradle/action.yml
+++ b/.github/actions/updateGradle/action.yml
@@ -6,6 +6,10 @@ inputs:
       The expected stage of the release. Might be current,
       release-candidate, release-nightly or nightly.
     required: true
+outputs:
+  update_successful:
+    description: >-
+      Is set if the update was successful, unset otherwise.
 runs:
   using: 'node12'
   main: 'index.js'

--- a/.github/workflows/gradleNightlyCheck.yml
+++ b/.github/workflows/gradleNightlyCheck.yml
@@ -27,19 +27,23 @@ jobs:
     # Update gradle
     - name: Update Gradle
       uses: ./.github/actions/updateGradle
+      id: gradle-update
       with:
         stage: ${{ matrix.stage }}
     # Build
     - name: Build with Gradle
+      id: gradle-build
+      if: success() && steps.gradle-update.outputs.update_successful
       run: ./gradlew projectReport build
     # Upload build artifacts
     - name: Upload build artifacts
       uses: actions/upload-artifact@v2
+      if: steps.gradle-build.outcome == 'success'
       with:
         name: build-artifacts
         path: build/libs/
     - name: Upload build reports
-      if: always()
+      if: steps.gradle-build.outcome == 'success' || steps.gradle-build.outcome == 'failure'
       uses: actions/upload-artifact@v2
       with:
         name: build-reports


### PR DESCRIPTION
The error was caused by Gradle's versions API responding with `{}` for
stage `release-candidate` after version 6.6 was released. There was no
up-to-date release candidate because the latest release (6.6) replaced
the latest release candidate.